### PR TITLE
Add --include-provided-path option

### DIFF
--- a/purgedirs.py
+++ b/purgedirs.py
@@ -9,21 +9,29 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument("path", type=click.Path(exists=True, file_okay=False))
 @click.option(
+    "--include-provided-path",
+    is_flag=True,
+    help="Delete the path provided as well, assuming all other criteria are met."
+)
+@click.option(
     "-d",
     "--dry-run",
     is_flag=True,
     help="Just show directories that would be deleted, but don't delete them.")
-def cli(path, dry_run):
+def cli(path, dry_run, include_provided_path):
     """Delete all directories under the directory provided if they're empty."""
 
     if dry_run:
         click.echo(empty_directories(path))
     else:
-        for path in empty_directories(path):
+        for path in empty_directories(path, include_provided_path):
             shutil.rmtree(path)
             click.echo("Removing: {0}".format(path))
 
 
-def empty_directories(path):
-    return [os.path.abspath(x[0]) for x in os.walk(
+def empty_directories(path, include_provided_path=False):
+    directories = [os.path.abspath(x[0]) for x in os.walk(
         path, topdown=False) if not x[2]]
+    if not include_provided_path:
+        directories.pop()
+    return directories

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='purgedirs',
-    version='0.0.1',
+    version='0.0.2',
     py_modules=['purgedirs'],
     install_requires=[
         'Click',

--- a/test_purgedirs.py
+++ b/test_purgedirs.py
@@ -13,7 +13,7 @@ from purgedirs import cli, empty_directories
 def mock_os_walk(monkeypatch):
     def mock_values(*args, **kwargs):
         return [("dir1", ["dir2", "dir3", "dir4"], ["file1"]),
-                ("dir5", ["dir6", "dir7", "dir8"], []), ]
+                ("dir5", ["dir6", "dir7", "dir8"], []), (".", [], [])]
 
     monkeypatch.setattr("os.walk", mock_values)
 
@@ -39,6 +39,11 @@ def test_help_option(test_input):
 def test_dry_run_option(test_input, mock_os_walk):
     result = cli_runner()(test_input)
     assert "dir5" in result.output
+
+
+def test_include_provided_path_option(mock_os_walk):
+    result = cli_runner()(["--include-provided-path"])
+    assert "." in result.output
 
 
 @pytest.mark.parametrize("test_input", [(["."]), ])


### PR DESCRIPTION
Add option to --include-provided-path which will include the path
provided as the path argument in the deletion, assuming all other
criteria are met. By default, this is not true.

Issue: #1 
